### PR TITLE
Could com.qlangtech.tis:tis-web-start-api:3.5.0 drop off redundant dependencies? 

### DIFF
--- a/tis-web-start-api/pom.xml
+++ b/tis-web-start-api/pom.xml
@@ -32,6 +32,13 @@
 
     <dependencies>
 
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.0</version>
+            <type>jar</type>
+            <scope>provided</scope>
+        </dependency>
 
     </dependencies>
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/78527112/164143093-302ae270-97cc-46ee-93a3-f5fbc0814510.png)
This figure presents the dependency tree between multiple modules in **_tis_**. As shown in this figure, Library **_ch.qos.logback:logback-classic:jar:1.2.0:compile, ch.qos.logback:logback-core:jar:1.2.0:compile_** in
##
<module>xmodifier</module>
        <module>tis-builder-api</module>
        <module>tis-manage-pojo</module>
        <module>tis-hadoop-rpc</module>
        <module>tis-solrconfig-parser</module>
        <module>tis-solrj-client</module>
        <module>tis-common</module>
        <module>tis-base-test</module>
        <module>tis-web-start-api</module>
        <module>tis-web-start</module>
        <module>tis-assemble</module>
        <module>tis-plugin-sezpoz</module>
        <module>tis-plugin</module>
        <module>tis-dag</module>
        <module>tis-sql-parser</module>
        <module>tis-common-dao</module>
        <module>tis-collection-info-collect</module>
        <module>tis-console</module>
        <module>tis-scala-compiler</module>
        <module>maven-tpi-plugin</module>
        <module>tis-datax-executor</module>

---
is inherited from their parent module. However, it is only not used by **_tis-web-start-api_**. We can perform refactoring operations in the pom, by removing such redundant dependencies in **_tis-web-start-api_**.

Specifically, the scope of **_ch.qos.logback:logback-classic:jar:1.2.0:compile, ch.qos.logback:logback-core:jar:1.2.0:compile_** in **_tis-web-start-api_** can be changed from **_compile_** to **_provided_**. The revisions in the pom are described as follows:
![image](https://user-images.githubusercontent.com/78527112/164143557-e34de6bd-eec6-4a51-ad5a-56d2fccde76a.png)

Removing the redundant dependencies can reduce the size of project and prevent potential dependency conflict issues (i.e., multiple versions of the same library). More importantly, one of the redundant dependencies **_ch.qos.logback:logback-core:jar:1.2.0:compile_** incorporates a medium-level vulnerability SNYK-JAVA-CHQOSLOGBACK-1726923. As such, I suggest a refactoring operation for **_com.qlangtech.tis:tis-web-start-api:3.5.0_**’s pom file.
